### PR TITLE
override_tvs.conf: remove invalid IDs

### DIFF
--- a/conf/override_tvs.conf
+++ b/conf/override_tvs.conf
@@ -8,33 +8,24 @@
 ## you can add own rules in override.conf
 # -----------------------------------------------------------------
 
-regexTitleChannel->id;alpha-thema Gespräch.*;;TheTVDB_Series;446063
 regexTitleChannel->id;Auf dem Nockherberg \d{4};;TheTVDB_Series;325215
-regexTitleChannel->id;Baumhaus;KiKA HD;TheTVDB_Series;444939
 regexTitleChannel->id;Brisant( [C|c]lassix)?;;TheTVDB_Series;360443
-regexTitleChannel->id;buten un binnen.*;;TheTVDB_Series;445896
 regexTitleChannel->id;Checkpoint;KiKA HD;TheTVDB_Series;327497
 regexTitleChannel->id;Dokumentation;phoenix HD;TheTVDB_Series;84589
 regexTitleChannel->id;Durch die Wildnis;KiKA HD;TheTVDB_Series;280218
 regexTitleChannel->id;(.*ischer|Orthodoxer) Gottesdienst;ZDF HD;TheTVDB_Series;358451
-regexTitleChannel->id;Extra;tagesschau24 HD;TheTVDB_Series;445894
 regexTitleChannel->id;Face to Face.*;NHK World-JPN;TheTVDB_Series;358480
-regexTitleChannel->id;Glockenläuten .*;;TheTVDB_Series;445394
 regexTitleChannel->id;[H|h]eimspiel.*;HR Fernsehen HD;TheTVDB_Series;445729
-regexTitleChannel->id;.*[H|h]essenquiz;;TheTVDB_Series;445762
 regexTitleChannel->id;HIMMEL & ERDE - .*;;TheTVDB_Series;425763
 regexTitleChannel->id;Maibockanstich \d{4};;TheTVDB_Series;351922
 regexTitleChannel->id;.*Mainz bleibt Mainz, wie es singt und lacht.*;;TheTVDB_Series;417294
 regexTitleChannel->id;mareTV.*;;TheTVDB_Series;190211
-regexTitleChannel->id;nachtlinie.*;;TheTVDB_Series;443977
 regexTitleChannel->id;.*:newstime;;TheTVDB_Series;445756
 regexTitleChannel->id;Panoramabilder.*|Alpenpanorama;;TheTVDB_Series;443192
 regexTitleChannel->id;Rising.*;NHK World-JPN;TheTVDB_Series;333384
 regexTitleChannel->id;Rundschau;3sat HD;TheTVDB_Series;323197
 regexTitleChannel->id;SAT.1-Frühstücksfernsehen.*;;TheMovieDB_Series;46044
 regexTitleChannel->id;Schwaben weissblau.*;;TheTVDB_Series;444585
-regexTitleChannel->id;Sehen statt Hören.*;;TheTVDB_Series;444525
-regexTitleChannel->id;Shift;tagesschau24 HD;TheTVDB_Series;444946
 regexTitleChannel->id;Spektakuläre Bergbahnen der Schweiz.*;;TheMovieDB_Series;214797
 regexTitleChannel->id;Sportclub live.*;;TheTVDB_Series;386459
 regexTitleChannel->id;Sportschau .*;;TheMovieDB_Series;29475
@@ -63,12 +54,10 @@ regexTitleChannel->idEpisodeName;Die Tricks (.+);;TheTVDB_Series;369398
 regexTitleChannel->idEpisodeName;Die Wahrheit über... (.+);;TheTVDB_Series;328886
 regexTitleChannel->idEpisodeName;(.+). Ein Krimi aus Passau;;TheTVDB_Series;373046
 regexTitleChannel->idEpisodeName;Gartenreise durch (.+);;TheMovieDB_Series;211289
-regexTitleChannel->idEpisodeName;Glaubwürdig: (.+);;TheTVDB_Series;446054
 regexTitleChannel->idEpisodeName;.*Inspektor Barbarotti - (.+);;TheTVDB_Series;258163
 regexTitleChannel->idEpisodeName;Hoch hinaus.*: (.+);;TheTVDB_Series;443064
 regexTitleChannel->idEpisodeName;(.+) in kabarett\.com;;TheTVDB_Series;334295
 regexTitleChannel->idEpisodeName;Kräuterwelten (.+);;TheTVDB_Series;323003
-regexTitleChannel->idEpisodeName;Kochstories: (.+);;TheTVDB_Series;445649
 regexTitleChannel->idEpisodeName;Lichters Originale - (.+);;TheTVDB_Series;365828
 regexTitleChannel->idEpisodeName;Märkte - Im Bauch von (.+);;TheTVDB_Series;298394
 regexTitleChannel->idEpisodeName;Marie Brand und (.+);;TheTVDB_Series;196041
@@ -106,7 +95,6 @@ regexTitleShortTextChannel->idEpisodeName;Fernweh: Zug um Zug.*;(.+);;TheTVDB_Se
 regexTitleShortTextChannel->idEpisodeName;(.+);freizeit;;TheTVDB_Series;359441
 regexTitleShortTextChannel->idEpisodeName;(.+);Heimatflimmern;;TheTVDB_Series;386001
 regexTitleShortTextChannel->idEpisodeName;(.+);.*"herkules";;TheTVDB_Series;446499
-regexTitleShortTextChannel->idEpisodeName;(.+);.*Hessen à la carte.*;;TheTVDB_Series;445176
 regexTitleShortTextChannel->idEpisodeName;(.+);.*Heute im Osten.*;;TheTVDB_Series;445968
 regexTitleShortTextChannel->idEpisodeName;(.+);Kleines Land ganz groß;;TheTVDB_Series;399778
 regexTitleShortTextChannel->idEpisodeName;(.+);Kochstories;;TheTVDB_Series;445649
@@ -120,30 +108,24 @@ regexTitleShortTextChannel->idEpisodeName;(.+);ZDF-Morgenmagazin;;TheTVDB_Series
 regexTitleShortTextChannel->idEpisodeName;Zu Tisch;(.+);;TheTVDB_Series;140511
 
 
-TheTVDB_SeriesID;10 vor 10;445595
 TheTVDB_SeriesID;Abendschau;444045
 TheTVDB_SeriesID;Abendschau - Der Süden;444045
 TheTVDB_SeriesID;Abenteuer Wildnis;426136
-TheTVDB_SeriesID;alle wetter!;445395
 TheTVDB_SeriesID;Alpen-Donau-Adria;444259
 TheTVDB_SeriesID;Anonyme Mütter;444145
 TheTVDB_SeriesID;ARD-Buffet;445276
 TheTVDB_SeriesID;ARD-Morgenmagazin;380312
-TheTVDB_SeriesID;ARD-Mittagsmagazin;445327
 TheTVDB_SeriesID;ARTE Journal;443203
 TheTVDB_SeriesID;ARTE Journal Junior;443965
 TheTVDB_SeriesID;aspekte;377074
 TheTVDB_SeriesID;Aus dem Feuer geboren: Die Kanaren;435227
 TheTVDB_SeriesID;Barbara Salesch - Das Strafgericht;433410
 TheTVDB_SeriesID;Bayern erleben;331684
-TheTVDB_SeriesID;Berlin direkt;445369
 TheTVDB_SeriesID;Bergauf-Bergab;434336
 TheTVDB_SeriesID;BR retro;431941
-TheTVDB_SeriesID;Das Wort zum Sonntag;445001
 TheTVDB_SeriesID;Design X Stories;435833
 TheTVDB_SeriesID;Die Mathias Richling Show;445378
 TheTVDB_SeriesID;Die Närrische Weinprobe;444485
-TheTVDB_SeriesID;Die Ratgeber;445344
 TheTVDB_SeriesID;Die Tierärzte - Retter mit Herz;445346
 TheTVDB_SeriesID;Document 72 Hours;323119
 TheTVDB_SeriesID;Einfach. Gut. Bachmeier;444749
@@ -151,21 +133,14 @@ TheTVDB_SeriesID;Einfach und köstlich - Heimatküche mit Björn Freitag;336407
 TheTVDB_SeriesID;Ermittler!;349810
 TheTVDB_SeriesID;Euroblick;444307
 TheTVDB_SeriesID;EUROBLICK;444307
-TheTVDB_SeriesID;Euromaxx;442206
-TheTVDB_SeriesID;Europamagazin;445018
-TheTVDB_SeriesID;Fastnacht in Franken;416793
 TheTVDB_SeriesID;Felix und die wilden Tiere;267769
 TheTVDB_SeriesID;Frankenschau aktuell;444309
 TheTVDB_SeriesID;Gefragt - Gejagt;323301
 TheTVDB_SeriesID;Grand Sumo Highlights;391618
 TheTVDB_SeriesID;Grand Sumo Live;425210
-TheTVDB_SeriesID;hallo deutschland;445317
 TheTVDB_SeriesID;Hello! NHK World-Japan;445557
-TheTVDB_SeriesID;heute - in Deutschland;445333
-TheTVDB_SeriesID;heute - in Europa;445328
 TheTVDB_SeriesID;heute Xpress;380313
 TheTVDB_SeriesID;heute-show spezial;234791
-TheTVDB_SeriesID;hessenschau;443200
 TheTVDB_SeriesID;J-Arena;348365
 TheTVDB_SeriesID;Kabarett aus Franken;444319
 TheTVDB_SeriesID;Kochstories;445649
@@ -173,42 +148,26 @@ TheTVDB_SeriesID;Komödie aus Franken;389587
 TheTVDB_SeriesID;Kripo Live - Tätern auf der Spur;362952
 TheTVDB_SeriesID;Kulturzeit;445718
 TheTVDB_SeriesID;Länder - Menschen - Abenteuer;289865
-TheTVDB_SeriesID;Länderspiegel;444978
-TheTVDB_SeriesID;Ländermagazin;445368
 TheTVDB_SeriesID;Little Charo;361697
 TheTVDB_SeriesID;logo!;265902
-TheTVDB_SeriesID;Lotto am Mittwoch - Die Gewinnzahlen;445340
-TheTVDB_SeriesID;Lotto am Samstag;445334
 TheTVDB_SeriesID;Lubi - Ein Polizist stürzt ab;440683
-TheTVDB_SeriesID;maintower;443201
 TheTVDB_SeriesID;maintower weekend;443201
 TheTVDB_SeriesID;Matsuri: The Heartbeat of Japan;445524
-TheTVDB_SeriesID;MDR aktuell;445096
 TheTVDB_SeriesID;MDR Garten;428218
-TheTVDB_SeriesID;MDR SACHSENSPIEGEL;445382
-TheTVDB_SeriesID;MDR SACHSEN-ANHALT HEUTE;445383
-TheTVDB_SeriesID;MDR THÜRINGEN JOURNAL;445384
-TheTVDB_SeriesID;MDR um 2;445094
 TheTVDB_SeriesID;MDR um 4;443898
 TheTVDB_SeriesID;Meister des Alltags;443768
 TheTVDB_SeriesID;mein ausland;364293
 TheTVDB_SeriesID;Mensch Heimat;445377
-TheTVDB_SeriesID;Mit Herz am Herd;444878
 TheTVDB_SeriesID;Mitternachtsspitzen;355035
 TheTVDB_SeriesID;Musik für Sie;445732
 TheTVDB_SeriesID;My Street Piano;443849
 TheTVDB_SeriesID;nano;266936
-TheTVDB_SeriesID;natur exclusiv;435753
-TheTVDB_SeriesID;NDR Info;445869
 TheTVDB_SeriesID;Newsroom Tokyo;421814
 TheTVDB_SeriesID;Newsline Biz;445522
 TheTVDB_SeriesID;Newsline In Depth;445521
 TheTVDB_SeriesID;Nordmagazin;444043
 TheTVDB_SeriesID;Onkel Bräsig;398492
-TheTVDB_SeriesID;Panorama;445695
-TheTVDB_SeriesID;phoenix der tag;444627
 TheTVDB_SeriesID;phoenix vor ort;377495
-TheTVDB_SeriesID;Presseclub;444066
 TheTVDB_SeriesID;Plusminus;328004
 TheTVDB_SeriesID;Querbeet extra;288184
 TheTVDB_SeriesID;Quickie;445407
@@ -220,15 +179,12 @@ TheTVDB_SeriesID;RTL Aktuell;379718
 TheTVDB_SeriesID;Sag die Wahrheit;331241
 TheTVDB_SeriesID;Schmecksperimente;444972
 TheTVDB_SeriesID;Schnittgut. Alles aus dem Garten;428222
-TheTVDB_SeriesID;Schwaben + Altbayern;444063
 TheTVDB_SeriesID;SMS - Schwanke meets Science;360766
 TheTVDB_SeriesID;Stadt Land Kunst;353085
-TheTVDB_SeriesID;Stadt, Land, Lecker;445335
 TheTVDB_SeriesID;Startrampe;396063
 TheTVDB_SeriesID;STATIONEN;349296
 TheTVDB_SeriesID;SUPER.MARKT;336828
 TheTVDB_SeriesID;SWR Morningshow;445232
-TheTVDB_SeriesID;The Day - News in Review;444563
 TheTVDB_SeriesID;The Quest for Ancient Colour;445542
 TheTVDB_SeriesID;Tigerenten Club;419076
 TheTVDB_SeriesID;Time-Lapse Japan;416748
@@ -236,20 +192,13 @@ TheTVDB_SeriesID;Unser Dorf hat Wochenende;445080
 TheTVDB_SeriesID;Unser Land in den 50ern;418459
 TheTVDB_SeriesID;Verklag mich doch!;364853
 TheTVDB_SeriesID;Viewpoint Science;445556
-TheTVDB_SeriesID;Visite;445363
 TheTVDB_SeriesID;Volle Kanne - Service täglich;393356
 TheTVDB_SeriesID;WER WEISS ES?;445033
-TheTVDB_SeriesID;Wetter für 3;445403
-TheTVDB_SeriesID;Wetter vor acht;445341
-TheTVDB_SeriesID;Wir in Bayern;442204
-TheTVDB_SeriesID;Wirtschaft vor acht;445078
 TheTVDB_SeriesID;WISO;340900
 TheTVDB_SeriesID;Zahn um Zahn;156001
-TheTVDB_SeriesID;ZDF-Morgenmagazin;445015
 TheTVDB_SeriesID;ZDF Royal;349565
 TheTVDB_SeriesID;Zoobabies;285075
 TheTVDB_SeriesID;Zu Tisch;140511
-TheTVDB_SeriesID;Zwischen Spessart und Karwendel;443236
 
 TheMovieDB_SeriesID;A Cat's-Eye View of Japan;205513
 TheMovieDB_SeriesID;Anime Manga Explosion;226741


### PR DESCRIPTION
Here are some invalid IDs I found in my syslog